### PR TITLE
fix readme spell error & add some comment in config example

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ cd $GOPATH/src/github.com/open-falcon/mymon
 make
 
 # Add to crontab
-echo '* * * * * cd ${WORKPATH} && ./mymon -c etc/mymon.cfg' > /etc/cron.d/mymon
+echo '* * * * * cd ${WORKPATH} && ./mymon -c etc/myMon.cfg' > /etc/cron.d/mymon
 ```
 
 ## Configuration

--- a/etc/myMon.cfg
+++ b/etc/myMon.cfg
@@ -1,17 +1,35 @@
-[default] log_file=mymon.log # Panic 0 # Fatal 1
-# Error 2
-# Warn 3
-# Info 4
-# Debug 5
-log_level=5
-
+[default]
+# 工作目录
+basedir = .
+# 日志目录，默认日志文件为myMon.log,旧版本有log_file项，如果同时设置了，会优先采用log_file
+log_dir = .
+# 配置忽略的metric项
+ignore_file = ./falconignore
+# 保存快照(process, innodb status)的目录
+snapshot_dir = ./snapshot
+# 保存快照的时间(日)
+snapshot_day = 10
+# 日志级别[RFC5424]
+# 0 Emergency
+# 1 Alert
+# 2 Critical
+# 3 Error
+# 4 Warning
+# 5 Notice
+# 6 Informational
+# 7 Debug
+log_level  = 5
+# falcon agent连接地址
 falcon_client=http://127.0.0.1:1988/v1/push
-
-#自定义endpoint
-endpoint=
+# 自定义endpoint
+#endpoint=
 
 [mysql]
+# 数据库用户名
 user=root
+# 您的数据库密码
 password=1tIsB1g3rt
+# 数据库连接地址
 host=127.0.0.1
+# 数据库端口
 port=3306


### PR DESCRIPTION
1. Fix a README spell error
2. Add more comment in `myMon.cfg`, which is an example config file.