### PR TITLE
fix config panic and do not collect binary logs when binary log is disabled

### DIFF
--- a/common/config.go
+++ b/common/config.go
@@ -16,6 +16,7 @@ package common
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/go-ini/ini"
 )
@@ -59,12 +60,12 @@ func readConf(file string) (conf Config, err error) {
 		file = fmt.Sprint("etc/", file)
 		_, err = os.Stat(file)
 		if err != nil {
-			panic(err)
+			return conf, fmt.Errorf("default config file: %s or %s: is not exist.", strings.TrimPrefix(file, "etc/"), file)
 		}
 	}
 	cfg, err := ini.Load(file)
 	if err != nil {
-		panic(err)
+		return conf, err
 	}
 	snapshotDay, err := cfg.Section("default").Key("snapshot_day").Int()
 	if err != nil {


### PR DESCRIPTION
修复两个bug:

- 当默认配置文件`myMon.cfg`和`etc/myMon.cfg`不存在时，直接返回配置文件不错在的报错
- 当`bin-log`没有开启的时候，`ShowBinaryLogs`方法返回的`errr`不为`nil`，导致`fetchData`方法直接退出，已经收集到的所有信息都不能上报，修复方法是: 先检查`bin-log`是否启用，如果没有启用就退出，返回`nil error`
#51
@MistShi @UlricQin 